### PR TITLE
fix: do not close menu if item is a dropdown

### DIFF
--- a/js/creative.js
+++ b/js/creative.js
@@ -23,7 +23,7 @@
     })
 
     // Closes the Responsive Menu on Menu Item Click
-    $('.navbar-collapse ul li a').click(function() {
+    $('.navbar-collapse ul li a:not(.dropdown-toggle)').click(function() {
         $('.navbar-toggle:visible').click();
     });
 


### PR DESCRIPTION
If a menuitem is a submenu, then the navbar will be closed when the user tap on it.