### PR TITLE
Higher opacity on .portfolio-box for smaller displays

### DIFF
--- a/css/creative.css
+++ b/css/creative.css
@@ -318,6 +318,12 @@ header .header-content .header-content-inner p {
     }
 }
 
+@media(max-width:991px) {
+  .portfolio-box .portfolio-box-caption {
+      opacity: .7;
+  }
+}
+
 .call-to-action h2 {
     margin: 0 auto 20px;
 }


### PR DESCRIPTION
Makes the .portfolio-box slightly opaque when the display is 990px wide or less. It does not make sense to wait for a :hover event when using a tablet or phone to display the website, this way the colored shade & text in portfolio boxes will be 70% visible by default on smaller screens (After some testing, I chose 990px for tablets and phones) and fully opaque when tapped/clicked.