### PR TITLE
Fixed Navigation Issue with "Get Started!" button

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
                     <h2 class="section-heading">We've got what you need!</h2>
                     <hr class="light">
                     <p class="text-faded">Start Bootstrap has everything you need to get your new website up and running in no time! All of the templates and themes on Start Bootstrap are open source, free to download, and easy to use. No strings attached!</p>
-                    <a href="#" class="btn btn-default btn-xl">Get Started!</a>
+                    <a href="#services" class="btn btn-default btn-xl">Get Started!</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The "Get Started" button was unlinked in the original demo file. I fixed it so that it navigates to the "Services" section for completeness.