### PR TITLE
Adds deploy button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Start Bootstrap was created by and is maintained by **[David Miller](http://davi
 
 Start Bootstrap is based on the [Bootstrap](http://getbootstrap.com/) framework created by [Mark Otto](https://twitter.com/mdo) and [Jacob Thorton](https://twitter.com/fat).
 
+## Deploy
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/BlackrockDigital/startbootstrap-creative)
+
 ## Copyright and License
 
 Copyright 2013-2016 Blackrock Digital LLC. Code released under the [MIT](https://github.com/BlackrockDigital/startbootstrap-creative/blob/gh-pages/LICENSE) license.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = ""
+  publish = "/"


### PR DESCRIPTION
# What is this?

I opened this PR to add a Netlify example and one click deploy button. The netlify.toml file just populates the build command bundle output location.

test out the button here:

[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/bdougie/startbootstrap-creative)

Let me know if you have any questions. Also if you have interest we offer a free plan at Netlify for all open source projects, check out the details [here](https://netlify.com/open-source) if you or the Blackrock team are interested in using it for more startbootstrap examples or even https://startbootstrap.com/.

Cheers 🎉 