### PR TITLE
Fix for bootstrap dropdown menu

### DIFF
--- a/js/creative.js
+++ b/js/creative.js
@@ -17,7 +17,7 @@
     });
 
     // Closes the Responsive Menu on Menu Item Click
-    $('.navbar-collapse ul li a').click(function() {
+    $('.navbar-collapse ul li a.page-scroll').click(function() {
         $('.navbar-toggle:visible').click();
     });
 


### PR DESCRIPTION
If a dropdown menu is added to the navbar the Responsive Menu is closed by clicking on the dropdown-toggle instead of showing the dropdown-menu. Adding the class page-scroll to the a tag fixes this.