### PR TITLE
Use 'tel:' link markup for the phone number.

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,8 @@
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
 
+    <!-- Avoid iOS phone link style override -->
+    <meta name="format-detection" content="telephone=no">
 </head>
 
 <body id="page-top">
@@ -251,7 +253,7 @@
                 </div>
                 <div class="col-lg-4 col-lg-offset-2 text-center">
                     <i class="fa fa-phone fa-3x sr-contact"></i>
-                    <p>123-456-6789</p>
+                    <p><a href="tel:phone-number-here" rel="nofollow">123-456-6789</a></p>
                 </div>
                 <div class="col-lg-4 text-center">
                     <i class="fa fa-envelope-o fa-3x sr-contact"></i>


### PR DESCRIPTION
The email address in the `Let's Get In Touch!` section is linked using `mailto:`. Thinking mobile-first, the phone number should be linked with the `tel:` protocol handler.

See also: [The Current State of Telephone Links](https://css-tricks.com/the-current-state-of-telephone-links/) from CSS-TRICKS.